### PR TITLE
Allow help to exit with status code 0

### DIFF
--- a/cmd/yaml-patch/main.go
+++ b/cmd/yaml-patch/main.go
@@ -17,8 +17,14 @@ type opts struct {
 func main() {
 	var o opts
 	_, err := flags.Parse(&o)
+
 	if err != nil {
-		log.Fatalf("error: %s\n", err)
+		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
+			os.Exit(0)
+		} else {
+			log.Fatalf("error: %s\n", err)
+			os.Exit(1)
+		}
 	}
 
 	placeholderWrapper := yamlpatch.NewPlaceholderWrapper("{{", "}}")


### PR DESCRIPTION
Fixes error message when using the help option. Returns a 0 on exit instead of 1. 

Current way:
```
yaml-patch --help
Usage:
  yaml-patch [OPTIONS]

Application Options:
  -o, --ops-file=PATH    Path to file with one or more operations

Help Options:
  -h, --help             Show this help message

2017/07/25 16:39:59 error: Usage:
  yaml-patch [OPTIONS]

Application Options:
  -o, --ops-file=PATH    Path to file with one or more operations

Help Options:
  -h, --help             Show this help message

>$ echo $?
1
```

With update:
```
yaml-patch --help
Usage:
  yaml-patch [OPTIONS]

Application Options:
  -o, --ops-file=PATH    Path to file with one or more operations

Help Options:
  -h, --help             Show this help message

>$ echo $?
0
```