### PR TITLE
Add support for multiple documents in the input stream

### DIFF
--- a/patch.go
+++ b/patch.go
@@ -31,7 +31,7 @@ func (p Patch) Apply(doc []byte) ([]byte, error) {
 
 		err := docdec.Decode(&iface)
 		if err != nil {
-			return nil, fmt.Errorf("failed unmarshaling doc: %s\n\n%s", string(doc), err)
+			return nil, fmt.Errorf("failed to decode doc: %s\n\n%s", string(doc), err)
 		}
 
 		// Check for no more documents

--- a/patch.go
+++ b/patch.go
@@ -2,6 +2,7 @@ package yamlpatch
 
 import (
 	"fmt"
+	"bytes"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -23,35 +24,44 @@ func DecodePatch(bs []byte) (Patch, error) {
 
 // Apply returns a YAML document that has been mutated per the patch
 func (p Patch) Apply(doc []byte) ([]byte, error) {
-	var iface interface{}
-	err := yaml.Unmarshal(doc, &iface)
-	if err != nil {
-		return nil, fmt.Errorf("failed unmarshaling doc: %s\n\n%s", string(doc), err)
-	}
-
 	var c Container
-	c = NewNode(&iface).Container()
+	docdec := yaml.NewDecoder(bytes.NewReader(doc))
+    for {
+		var iface interface{}
 
-	for _, op := range p {
-		pathfinder := NewPathFinder(c)
-		if op.Path.ContainsExtendedSyntax() {
-			paths := pathfinder.Find(string(op.Path))
-			if paths == nil {
-				return nil, fmt.Errorf("could not expand pointer: %s", op.Path)
-			}
+		err := docdec.Decode(&iface)
+		if err != nil {
+			return nil, fmt.Errorf("failed unmarshaling doc: %s\n\n%s", string(doc), err)
+		}
 
-			for _, path := range paths {
-				newOp := op
-				newOp.Path = OpPath(path)
-				err = newOp.Perform(c)
+		// Check for no more documents
+		if iface == nil {
+        	break
+        }
+
+		c = NewNode(&iface).Container()
+
+		for _, op := range p {
+			pathfinder := NewPathFinder(c)
+			if op.Path.ContainsExtendedSyntax() {
+				paths := pathfinder.Find(string(op.Path))
+				if paths == nil {
+					return nil, fmt.Errorf("could not expand pointer: %s", op.Path)
+				}
+
+				for _, path := range paths {
+					newOp := op
+					newOp.Path = OpPath(path)
+					err = newOp.Perform(c)
+					if err != nil {
+						return nil, err
+					}
+				}
+			} else {
+				err = op.Perform(c)
 				if err != nil {
 					return nil, err
 				}
-			}
-		} else {
-			err = op.Perform(c)
-			if err != nil {
-				return nil, err
 			}
 		}
 	}

--- a/patch.go
+++ b/patch.go
@@ -30,14 +30,14 @@ func (p Patch) Apply(doc []byte) ([]byte, error) {
 		var iface interface{}
 
 		err := docdec.Decode(&iface)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode doc: %s\n\n%s", string(doc), err)
-		}
-
 		// Check for no more documents
 		if iface == nil {
         	break
-        }
+		}
+		
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode doc: %s\n\n%s", string(doc), err)
+		}
 
 		c = NewNode(&iface).Container()
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -524,7 +524,7 @@ baz: qux
 - corge: grault
 `,
 			),
-			Entry("a path that begins with an array index and ends with a composite key (multiple document)",
+			Entry("a path that begins with an array index and ends with a composite key (multiple documents)",
 				`---
 - waldo:
     - thud: boo
@@ -687,6 +687,20 @@ a:
   path: /a/b/2
 `,
 			),
+			Entry("moving an element from an array with a bad pointer (multiple documents, second with error case)",
+				`---
+a:
+  b: ["ateste1", "1"]
+---
+a:
+  b: [1]
+`,
+				`---
+- op: move
+  from: /a/b/1
+  path: /a/b/2
+`,
+			),
 			Entry("an operation with an invalid pathz field",
 				`---
 foo: bar
@@ -718,6 +732,26 @@ name:
 				`---
 - op: replace
   path: /foo/2
+  value: bum
+`,
+			),
+			Entry("a replace operation on an array with an invalid path (multiple documents, first with error case)",
+				`---
+name:
+  foo:
+    mal: goof
+  qux:
+    bum
+---
+name:
+  foo:
+    bat: bam
+  qux:
+    bum
+`,
+				`---
+- op: replace
+  path: /name/foo/bat
   value: bum
 `,
 			),


### PR DESCRIPTION
This changes Patch.Apply() to use the Decode() method provided by the yaml package instead of Unmarshal(), since Decode() supports decoding multiple documents.  